### PR TITLE
Fix: Fix version

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.0.4"
+current_version = "0.0.2"
 commit = true
 message = "Update version {current_version} -> {new_version} [skip ci]"
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-# sdsaas 0.0.4
+# sdsaas 0.0.2
 Go client library to interact with the various [IBM Cloud Sds Sdk APIs](https://cloud.ibm.com/apidocs?category=sds-go-sdk).
 
 Disclaimer: this SDK is being released initially as a **pre-release** version.
@@ -27,7 +27,7 @@ Changes might occur which impact applications that use this SDK.
 <!-- toc -->
 
 - [sds-go-sdk](#sds-go-sdk)
-- [sdsaas 0.0.4](#sdsaas-004)
+- [sdsaas 0.0.2](#sdsaas-002)
   - [Table of Contents](#table-of-contents)
   - [Overview](#overview)
   - [Prerequisites](#prerequisites)
@@ -60,7 +60,7 @@ Service Name | Package name
 * Go version 1.21 or above.
 
 ## Installation
-The current version of this SDK: 0.0.4
+The current version of this SDK: 0.0.2
 
 ### Go modules
 If your application uses Go modules for dependency management (recommended), just add an import for each service

--- a/common/version.go
+++ b/common/version.go
@@ -17,4 +17,4 @@
 package common
 
 // Version of the SDK
-const Version = "0.0.4"
+const Version = "0.0.2"


### PR DESCRIPTION
The semantic release tool didn't like the version being forced to v0.0.5. Reverting the versions so the semantic-release tool can handle it